### PR TITLE
Prevent rendering pages without annotations

### DIFF
--- a/src/PDFAnnotationsManager.ts
+++ b/src/PDFAnnotationsManager.ts
@@ -48,8 +48,10 @@ export default class PDFAnnotationsManager {
                             .filter(function (anno) {
                                 return SUPPORTED_ANNOTS.indexOf(anno.subtype) >= 0;
                             });
-
-                        await page.render(renderContext, annotations);
+                        
+                        if(annotations.length > 0) {
+                            await page.render(renderContext, annotations);
+                        }
 
                         annotations.map(function (anno) {
                             anno.pageNumber = pageNum;


### PR DESCRIPTION
Since rendering a page is a somewhat costly operation, pages shouldn't be rendered unless getAnnotations() returns more than 0 annotations. Otherwise, there is no reason to render. This will greatly reduce the processing time, and will likely make the plugin feel more responsive than it currently is.

Resolves #10 